### PR TITLE
Updated URLs to langrenn.org.ntnu.no

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # tidtakerhjelp
 Et verktøy for å lage resultatlister for NTNUI Langrenn sin hjemmeside.
 
-https://org.ntnu.no/langrenn/tidtakerhjelpen
+https://langrenn.org.ntnu.no/tidtakerhjelpen

--- a/src/app/infoside/infoside.component.html
+++ b/src/app/infoside/infoside.component.html
@@ -3,7 +3,7 @@
         <mat-card-title class="card__title">Info</mat-card-title>
         <mat-card-content class="card__content">
             <p>Denne siden er laget for at det skal gå raskere å legge inn resultater etter at man har arrangert hyttekarusell.</p>
-            <p>Den er basert på at man bruker PDF-dokumentet <a href="http://org.ntnu.no/langrenn/tidtaker/tidtaker_ark.pdf"><b>tidtaker_ark.pdf</b></a> eller tilsvarende når man tar tiden. 
+            <p>Den er basert på at man bruker PDF-dokumentet <a href="http://langrenn.org.ntnu.no/tidtaker/tidtaker_ark.pdf"><b>tidtaker_ark.pdf</b></a> eller tilsvarende når man tar tiden. 
                 Hvis dere er to arrangører lønner det seg at en skriver, mens den andre tar tiden. 
                 Skriv bare startnummer og tid underveis, hvis ikke blir det for mye å holde styr på.</p>
             <p>Når du oppretter et nytt arrangement får du en arrangementkode. Hvis du skal gjøre endringer senere kan denne brukes i søkefeltet øverst til høyre.</p>

--- a/src/app/services/opprett.service.ts
+++ b/src/app/services/opprett.service.ts
@@ -9,7 +9,7 @@ import { Arrangement } from "../models/arrangement.model";
   export class OpprettService {
     constructor (private http: HttpClient) {}
   
-    PHP_API_SERVER = "https://org.ntnu.no/langrenn/tidtakerhjelpen/api";
+    PHP_API_SERVER = "https://langrenn.org.ntnu.no/tidtakerhjelpen/api";
 
     opprettArr(arrangement: Arrangement): Observable<number> {
       return this.http.put<number>(this.PHP_API_SERVER + '/createArr.php', arrangement);

--- a/src/app/services/paamelding.service.ts
+++ b/src/app/services/paamelding.service.ts
@@ -10,7 +10,7 @@ import { Paamelding } from "../models/paamelding.model";
   export class PaameldingService {
     constructor (private http: HttpClient) {}
   
-    PHP_API_SERVER = "https://org.ntnu.no/langrenn/tidtakerhjelpen/api";
+    PHP_API_SERVER = "https://langrenn.org.ntnu.no/tidtakerhjelpen/api";
 
     getMedlemmer(): Observable<Medlem[]> {
       return this.http.get<Medlem[]>(this.PHP_API_SERVER + '/readMedlemmer.php');

--- a/src/app/services/resultatliste.service.ts
+++ b/src/app/services/resultatliste.service.ts
@@ -8,7 +8,7 @@ import { Observable } from "rxjs";
   export class ResultatlisteService {
     constructor (private http: HttpClient) {}
   
-    PHP_API_SERVER = "https://org.ntnu.no/langrenn/tidtakerhjelpen/api";
+    PHP_API_SERVER = "https://langrenn.org.ntnu.no/tidtakerhjelpen/api";
 
     getResultatliste(arrKode: number): Observable<string> {
         return this.http.get<string>(this.PHP_API_SERVER + '/getResultatliste.php/?arrKode='+arrKode);

--- a/src/app/services/tider.service.ts
+++ b/src/app/services/tider.service.ts
@@ -8,7 +8,7 @@ import { Observable } from "rxjs";
   export class TiderService {
     constructor (private http: HttpClient) {}
   
-    PHP_API_SERVER = "https://org.ntnu.no/langrenn/tidtakerhjelpen/api";
+    PHP_API_SERVER = "https://langrenn.org.ntnu.no/tidtakerhjelpen/api";
 
     getPasseringstider(arrKode: number): Observable<{id: number, startnr: number, tid: string}[]> {
         return this.http.get<{id: number, startnr: number, tid: string}[]>(this.PHP_API_SERVER + '/readPasseringstider.php/?arrKode='+arrKode);


### PR DESCRIPTION
Hei, siden Domenen til NTNUI sin hjemmeside endret seg til langrenn.org.ntnu.no måtte vi endre dette i koden til tidtakerhjelpen. Tenkte derfor at du kunne oppdatere koden her i repoen. 